### PR TITLE
Added CALCULATION_INPUT_VALIDATOR

### DIFF
--- a/src/main/resources/config/systemMMnn/CALCULATION_INPUT_VALIDATOR.json
+++ b/src/main/resources/config/systemMMnn/CALCULATION_INPUT_VALIDATOR.json
@@ -1,0 +1,19 @@
+{
+	"config": "CALCULATION_INPUT_VALIDATOR",
+	"name": "systemMMnn",
+	"configCondition": [
+        "feature",
+        "output"
+	],
+	"values": [
+        {
+            "value": "positiveValidator",
+            "output": [
+                "US"
+            ],
+            "feature": [
+                "n"
+            ]
+        }
+	]
+}


### PR DESCRIPTION
In system MMnn when calculating US n has to be larger than 0 to get a valid result (otherwise its infinity which is not a valid probability). I added a calculation input validator for this.